### PR TITLE
feat: add sync command for cross-machine reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ If your shell does not pick up the new PATH entry immediately, open a new termin
 
 ## Commands
 
+- `workdone sync`
+- `workdone sync --source <alias-or-path>`
 - `workdone report`
 - `workdone report --source <alias-or-path>`
 - `workdone report --files`
@@ -52,6 +54,15 @@ If your shell does not pick up the new PATH entry immediately, open a new termin
 - `workdone sources discover <folder> [--max-depth <n>] [--dry-run]`
 
 Weeks start on Monday in local time.
+
+To include work pushed from another machine, run:
+
+```bash
+workdone sync
+workdone report
+```
+
+`sync` runs `git fetch --all --prune` for your registered repos. `report` then scans commits from local branches and remote-tracking branches already present in each local clone, while still filtering by the current week and your global git email.
 
 ## Development
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { stat } from "node:fs/promises";
 import { loadConfig, saveConfig } from "./core/config";
 import { discoverGitRepos } from "./core/discover";
-import { getGlobalGitUserEmail } from "./core/git";
+import { getGlobalGitUserEmail, syncGitSource } from "./core/git";
 import { printReport, printValidationResults } from "./core/output";
 import { getConfigPath, normalizeInputPath } from "./core/paths";
 import { buildWeeklyReport } from "./core/report";
@@ -22,6 +22,7 @@ USAGE
 COMMANDS
   config                 Print config file location
   report                 Print your current week's report (use --source, --view, and --format)
+  sync                   Fetch all remotes for registered sources before reporting across machines
   sources list           List registered sources
   sources add <path>     Register a local git repository source (use --name for alias)
   sources remove <arg>   Remove a registered source by alias or path
@@ -35,10 +36,13 @@ GLOBAL OPTIONS
 
 GET STARTED
   workdone sources discover ~/code
+  workdone sync
   workdone sources validate
   workdone report --view timeline
 
 EXAMPLES
+  workdone sync
+  workdone sync --source myrepo
   workdone report
   workdone report --view timeline
   workdone report --view by-source
@@ -60,6 +64,9 @@ DESCRIPTION
 
   Includes only commits authored by your global git email:
   git config --global user.email
+
+  Scans commits reachable from local branches and remote-tracking
+  branches already present in the local clone.
 
 VIEWS
   timeline               Linear commit overview grouped by day (default)
@@ -84,6 +91,7 @@ OPTIONS
   -h, --help             Show help
 
 EXAMPLES
+  workdone sync
   workdone report
   workdone report --view timeline
   workdone report --view by-source
@@ -94,6 +102,31 @@ EXAMPLES
 REQUIREMENTS
   - git global user.email must be set
   - selected/registered source must be a valid local git repository`);
+}
+
+function printSyncHelp(): void {
+  console.log(`Fetch all remotes for registered sources.
+
+USAGE
+  workdone sync [options]
+
+DESCRIPTION
+  Runs 'git fetch --all --prune' for each selected source so work pushed
+  from another machine becomes available to local reporting.
+
+OPTIONS
+  -s, --source <source>  Sync one source by alias or path
+  -h, --help             Show help
+
+RESULT
+  - Prints one line per source: OK or FAIL
+  - Continues through all selected sources
+  - Exit code 0 when all sources synced, 1 when any source failed
+
+EXAMPLES
+  workdone sync
+  workdone sync --source api
+  workdone sync --source ~/code/work-repo`);
 }
 
 function printConfigHelp(): void {
@@ -455,6 +488,30 @@ function parseReportOptions(args: string[]): {
   return { sourceSelector, files, view, format };
 }
 
+function parseSyncOptions(args: string[]): { sourceSelector?: string } {
+  let sourceSelector: string | undefined;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    if (token === "-h" || token === "--help") {
+      printSyncHelp();
+      process.exit(0);
+    }
+    if (token === "--source" || token === "-s") {
+      const value = args[i + 1];
+      if (!value) {
+        fail("missing value for '--source'\nTry: workdone sync --help");
+      }
+      sourceSelector = value;
+      i += 1;
+      continue;
+    }
+    fail(`unknown option '${token}'\nTry: workdone sync --help`);
+  }
+
+  return { sourceSelector };
+}
+
 function findSourceByAliasOrPath(selector: string, sources: Source[]): Source | null {
   const alias = normalizeAlias(selector);
   const byAlias = sources.find((source) => normalizeAlias(source.name) === alias);
@@ -707,6 +764,55 @@ async function handleReport(args: string[]): Promise<void> {
   printReport(report, { includeFiles: options.files, view: options.view, format: options.format });
 }
 
+async function handleSync(args: string[]): Promise<void> {
+  const options = parseSyncOptions(args);
+  const config = await loadConfig();
+
+  if (config.sources.length === 0) {
+    console.log("No sources registered.");
+    console.log("Add one with: workdone sources add <path>");
+    return;
+  }
+
+  let selectedSources = config.sources;
+  if (options.sourceSelector) {
+    const selectedSource = findSourceByAliasOrPath(options.sourceSelector, config.sources);
+    if (!selectedSource) {
+      fail(`source not registered: ${options.sourceSelector}\nTry: workdone sources list`);
+    }
+    selectedSources = [selectedSource];
+  }
+
+  const validations = await validateSources(selectedSources);
+  const validSources = validations.filter((result) => result.valid).map((result) => result.source);
+  const invalidSources = validations.filter((result) => !result.valid);
+
+  let failureCount = 0;
+
+  for (const invalid of invalidSources) {
+    console.log(`FAIL ${invalid.source.name}  invalid source (${invalid.reason})`);
+    failureCount += 1;
+  }
+
+  for (const source of validSources) {
+    try {
+      await syncGitSource(source.path);
+      console.log(`OK   ${source.name}  fetched all remotes`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(`FAIL ${source.name}  ${message}`);
+      failureCount += 1;
+    }
+  }
+
+  const successCount = validSources.length - (failureCount - invalidSources.length);
+  console.log(`\nSynced ${successCount} sources, failed ${failureCount}`);
+
+  if (failureCount > 0) {
+    process.exit(1);
+  }
+}
+
 function printHelpForPath(pathParts: string[]): void {
   if (pathParts.length === 0) {
     printTopHelp();
@@ -719,6 +825,9 @@ function printHelpForPath(pathParts: string[]): void {
       return;
     case "report":
       printReportHelp();
+      return;
+    case "sync":
+      printSyncHelp();
       return;
     case "sources":
       printSourcesHelp();
@@ -773,6 +882,11 @@ async function main(): Promise<void> {
 
   if (command === "report") {
     await handleReport(args.slice(1));
+    return;
+  }
+
+  if (command === "sync") {
+    await handleSync(args.slice(1));
     return;
   }
 

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -28,6 +28,11 @@ function runGit(args: string[], cwd: string): Promise<ExecResult> {
   });
 }
 
+function gitErrorMessage(stderr: string): string {
+  const trimmed = stderr.trim();
+  return trimmed === "" ? "git command failed" : trimmed;
+}
+
 export async function isGitRepo(repoPath: string): Promise<boolean> {
   const result = await runGit(["rev-parse", "--is-inside-work-tree"], repoPath).catch(() => {
     return { stdout: "", stderr: "", code: 1 };
@@ -71,6 +76,15 @@ export async function getGlobalGitUserEmail(): Promise<string> {
   return email;
 }
 
+export async function syncGitSource(repoPath: string): Promise<void> {
+  const result = await runGit(["fetch", "--all", "--prune"], repoPath).catch(() => {
+    return { stdout: "", stderr: "", code: 1 };
+  });
+  if (result.code !== 0) {
+    throw new Error(gitErrorMessage(result.stderr));
+  }
+}
+
 function parseNumstat(line: string): FileChange | null {
   const parts = line.split("\t");
   if (parts.length < 3) {
@@ -106,6 +120,8 @@ export async function getWeeklyCommits(
   const format = `${COMMIT_PREFIX}%H|%aI|%ae|%s`;
   const args = [
     "log",
+    "--branches",
+    "--remotes",
     `--since=${sinceIso}`,
     `--until=${untilIso}`,
     `--pretty=format:${format}`,
@@ -114,7 +130,7 @@ export async function getWeeklyCommits(
 
   const result = await runGit(args, repoPath);
   if (result.code !== 0) {
-    throw new Error(`Failed to read git log for ${repoPath}: ${result.stderr.trim()}`);
+    throw new Error(`Failed to read git log for ${repoPath}: ${gitErrorMessage(result.stderr)}`);
   }
 
   const lines = result.stdout.split(/\r?\n/);

--- a/src/core/report.ts
+++ b/src/core/report.ts
@@ -1,6 +1,6 @@
 import { getWeeklyCommits } from "./git";
 import { getCurrentWeekRange, toDateKey, toDayLabel } from "./time";
-import type { DayGroup, Source, WeeklyReport } from "../types";
+import type { CommitEntry, DayGroup, Source, WeeklyReport } from "../types";
 
 export async function buildWeeklyReport(
   sources: Source[],
@@ -13,7 +13,7 @@ export async function buildWeeklyReport(
 
   const allCommits = filterCommitsByAuthorEmail(
     await Promise.all(sources.map((source) => getWeeklyCommits(source.path, source.name, sinceIso, untilIso)))
-      .then((results) => results.flat()),
+      .then((results) => dedupeCommitsByHash(results.flat())),
     authorEmail,
   );
 
@@ -52,4 +52,19 @@ export function filterCommitsByAuthorEmail<T extends { authorEmail: string }>(
 ): T[] {
   const expected = email.trim().toLowerCase();
   return commits.filter((commit) => commit.authorEmail.trim().toLowerCase() === expected);
+}
+
+export function dedupeCommitsByHash(commits: CommitEntry[]): CommitEntry[] {
+  const seen = new Set<string>();
+  const unique: CommitEntry[] = [];
+
+  for (const commit of commits) {
+    if (seen.has(commit.hash)) {
+      continue;
+    }
+    seen.add(commit.hash);
+    unique.push(commit);
+  }
+
+  return unique;
 }

--- a/tests/help.test.ts
+++ b/tests/help.test.ts
@@ -16,6 +16,7 @@ describe("help output", () => {
     const output = runCli(["--help"]);
     expect(output).toContain("config                 Print config file location");
     expect(output).toContain("report                 Print your current week's report (use --source, --view, and --format)");
+    expect(output).toContain("sync                   Fetch all remotes for registered sources before reporting across machines");
   });
 
   it("supports help config topic", () => {
@@ -38,5 +39,13 @@ describe("help output", () => {
     expect(output).toContain("-V, --view <view>      Report layout: timeline | by-source (default: timeline)");
     expect(output).toContain("-F, --format <format>  Output format: text | markdown (default: text)");
     expect(output).toContain("git config --global user.email");
+    expect(output).toContain("local branches and remote-tracking");
+  });
+
+  it("supports sync help topic", () => {
+    const output = runCli(["help", "sync"]);
+    expect(output).toContain("workdone sync [options]");
+    expect(output).toContain("git fetch --all --prune");
+    expect(output).toContain("-s, --source <source>  Sync one source by alias or path");
   });
 });

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { filterCommitsByAuthorEmail } from "../src/core/report";
+import { dedupeCommitsByHash, filterCommitsByAuthorEmail } from "../src/core/report";
 
 describe("report author filter", () => {
   it("keeps only commits from matching author email", () => {
@@ -12,5 +12,41 @@ describe("report author filter", () => {
     const filtered = filterCommitsByAuthorEmail(commits, "dev@example.com");
     expect(filtered).toHaveLength(2);
     expect(filtered.map((commit) => commit.hash)).toEqual(["a", "c"]);
+  });
+
+  it("deduplicates commits by exact hash", () => {
+    const commits = [
+      {
+        repoPath: "/tmp/repo",
+        repoName: "repo",
+        hash: "abc123",
+        authorEmail: "dev@example.com",
+        date: new Date("2026-03-19T10:00:00Z"),
+        subject: "First copy",
+        files: [],
+      },
+      {
+        repoPath: "/tmp/repo",
+        repoName: "repo",
+        hash: "abc123",
+        authorEmail: "dev@example.com",
+        date: new Date("2026-03-19T10:00:00Z"),
+        subject: "Duplicate copy",
+        files: [],
+      },
+      {
+        repoPath: "/tmp/repo",
+        repoName: "repo",
+        hash: "def456",
+        authorEmail: "dev@example.com",
+        date: new Date("2026-03-19T11:00:00Z"),
+        subject: "Unique copy",
+        files: [],
+      },
+    ];
+
+    const deduped = dedupeCommitsByHash(commits);
+    expect(deduped).toHaveLength(2);
+    expect(deduped.map((commit) => commit.hash)).toEqual(["abc123", "def456"]);
   });
 });


### PR DESCRIPTION
 ## Summary
 - add `workdone sync` to fetch all remotes with prune for all or selected registered repos
 - expand report commit discovery to local branches and remote-tracking branches with exact-hash deduplication
 - document the new cross-machine workflow and update help/tests