### PR TITLE
feat: add --last-week shortcut flag for report

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,6 +92,7 @@ DATE RANGE OPTIONS (mutually exclusive)
   --until <YYYY-MM-DD>   End date (23:59:59 local time); requires --since
   --today                Today from 00:00:00 until now
   --yesterday            Yesterday from 00:00:00 through 23:59:59
+  --last-week            Full previous ISO week (Mon 00:00:00 – Sun 23:59:59); same as --week=-1
   --this-month           First day of current month through now
   --last-month           Full previous calendar month
 
@@ -127,6 +128,7 @@ EXAMPLES
   workdone report --since 2026-03-20 --until 2026-03-30
   workdone report --today
   workdone report --yesterday
+  workdone report --last-week
   workdone report --this-month
   workdone report --last-month
   workdone report --view timeline
@@ -577,6 +579,13 @@ function parseReportOptions(args: string[]): {
         fail(`--last-month and --${shortcut} cannot be used together.\nTry: workdone report --help`);
       }
       shortcut = "last-month";
+      continue;
+    }
+    if (token === "--last-week") {
+      if (shortcut !== undefined) {
+        fail(`--last-week and --${shortcut} cannot be used together.\nTry: workdone report --help`);
+      }
+      shortcut = "last-week";
       continue;
     }
     fail(`unknown option '${token}'\nTry: workdone report --help`);

--- a/src/core/time.ts
+++ b/src/core/time.ts
@@ -195,7 +195,7 @@ export function resolveDateRange(since: string, until?: string, now: Date = new 
   return { start: sinceDate, end: untilDate };
 }
 
-export type Shortcut = "today" | "yesterday" | "this-month" | "last-month";
+export type Shortcut = "today" | "yesterday" | "last-week" | "this-month" | "last-month";
 
 /**
  * Returns a DateRange for a named shortcut relative to now.
@@ -223,6 +223,8 @@ export function resolveShortcutRange(shortcut: Shortcut, now: Date = new Date())
       const start = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0);
       return { start, end: now };
     }
+    case "last-week":
+      return resolveWeekRange({ kind: "relative", offset: -1 }, now);
     case "last-month": {
       const year = now.getMonth() === 0 ? now.getFullYear() - 1 : now.getFullYear();
       const month = now.getMonth() === 0 ? 11 : now.getMonth() - 1;

--- a/tests/e2e/__snapshots__/report.test.ts.snap
+++ b/tests/e2e/__snapshots__/report.test.ts.snap
@@ -1,97 +1,145 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`workdone report default timeline text view matches snapshot 1`] = `
-"Week starting 2026-03-30 (Monday, local time)
+"Week starting 2026-04-06 (Monday, local time)
 
-2026-03-31 (Tue)
+2026-04-08 (Wed)
 Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
 Time   Source       Hash     Files+  -  Δ  Bin  Subject
 -----  -----------  -------  -----  -  -  -  ---  -------
-11:00  repo-single  173889e      1  2  0  2    0  add user profile endpoint
+15:00  repo-single  326b258      1  2  0  2    0  fix token expiry validation
 
 -------------------------------------------------------------------------------
 
-2026-03-30 (Mon)
+2026-04-07 (Tue)
 Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
 Time   Source       Hash     Files+  -  Δ  Bin  Subject
 -----  -----------  -------  -----  -  -  -  ---  -------
-09:00  repo-single  946a847      1  2  0  2    0  add authentication middleware
+11:00  repo-single  3749dec      1  2  0  2    0  add user profile endpoint
+
+-------------------------------------------------------------------------------
+
+2026-04-06 (Mon)
+Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
+Time   Source       Hash     Files+  -  Δ  Bin  Subject
+-----  -----------  -------  -----  -  -  -  ---  -------
+09:00  repo-single  23573c8      1  2  0  2    0  add authentication middleware
 "
 `;
 
 exports[`workdone report by-source view matches snapshot 1`] = `
-"Week starting 2026-03-30 (Monday, local time)
+"Week starting 2026-04-06 (Monday, local time)
 
 ===============================================================================
 [repo-single]
-Source total: 2 commits, 2 files, +4 -0, 4, 0 binaries
+Source total: 3 commits, 3 files, +6 -0, 6, 0 binaries
 ===============================================================================
 
-2026-03-31 (Tue)
+2026-04-08 (Wed)
 Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
 Time   Hash     Files+  -  Δ  Bin  Subject
 -----  -------  -----  -  -  -  ---  -------
-11:00  173889e      1  2  0  2    0  add user profile endpoint
+15:00  326b258      1  2  0  2    0  fix token expiry validation
 
 -------------------------------------------------------------------------------
 
-2026-03-30 (Mon)
+2026-04-07 (Tue)
 Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
 Time   Hash     Files+  -  Δ  Bin  Subject
 -----  -------  -----  -  -  -  ---  -------
-09:00  946a847      1  2  0  2    0  add authentication middleware
+11:00  3749dec      1  2  0  2    0  add user profile endpoint
+
+-------------------------------------------------------------------------------
+
+2026-04-06 (Mon)
+Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
+Time   Hash     Files+  -  Δ  Bin  Subject
+-----  -------  -----  -  -  -  ---  -------
+09:00  23573c8      1  2  0  2    0  add authentication middleware
 "
 `;
 
 exports[`workdone report markdown format matches snapshot 1`] = `
 "# Workdone Report
-Week starting: 2026-03-30 (Monday, local time)
+Week starting: 2026-04-06 (Monday, local time)
 
-## 2026-03-31 (Tue)
+## 2026-04-08 (Wed)
 Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
 
 | Time | Source | Hash | Files | + | - | Δ | Bin | Subject |
 |---|---|---|---:|---:|---:|---:|---:|---|
-| 11:00 | repo-single | 173889e | 1 | 2 | 0 | 2 | 0 | add user profile endpoint |
+| 15:00 | repo-single | 326b258 | 1 | 2 | 0 | 2 | 0 | fix token expiry validation |
 
-## 2026-03-30 (Mon)
+## 2026-04-07 (Tue)
 Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
 
 | Time | Source | Hash | Files | + | - | Δ | Bin | Subject |
 |---|---|---|---:|---:|---:|---:|---:|---|
-| 09:00 | repo-single | 946a847 | 1 | 2 | 0 | 2 | 0 | add authentication middleware |
+| 11:00 | repo-single | 3749dec | 1 | 2 | 0 | 2 | 0 | add user profile endpoint |
+
+## 2026-04-06 (Mon)
+Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
+
+| Time | Source | Hash | Files | + | - | Δ | Bin | Subject |
+|---|---|---|---:|---:|---:|---:|---:|---|
+| 09:00 | repo-single | 23573c8 | 1 | 2 | 0 | 2 | 0 | add authentication middleware |
 "
 `;
 
 exports[`workdone report --files flag matches snapshot 1`] = `
-"Week starting 2026-03-30 (Monday, local time)
+"Week starting 2026-04-06 (Monday, local time)
 
-2026-03-31 (Tue)
+2026-04-08 (Wed)
 Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
 Time   Source       Hash     Files+  -  Δ  Bin  Subject
 -----  -----------  -------  -----  -  -  -  ---  -------
-11:00  repo-single  173889e      1  2  0  2    0  add user profile endpoint
+15:00  repo-single  326b258      1  2  0  2    0  fix token expiry validation
+  token.ts (+2 -0, 2)
+
+-------------------------------------------------------------------------------
+
+2026-04-07 (Tue)
+Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
+Time   Source       Hash     Files+  -  Δ  Bin  Subject
+-----  -----------  -------  -----  -  -  -  ---  -------
+11:00  repo-single  3749dec      1  2  0  2    0  add user profile endpoint
   profile.ts (+2 -0, 2)
 
 -------------------------------------------------------------------------------
 
-2026-03-30 (Mon)
+2026-04-06 (Mon)
 Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
 Time   Source       Hash     Files+  -  Δ  Bin  Subject
 -----  -----------  -------  -----  -  -  -  ---  -------
-09:00  repo-single  946a847      1  2  0  2    0  add authentication middleware
+09:00  repo-single  23573c8      1  2  0  2    0  add authentication middleware
   auth.ts (+2 -0, 2)
 "
 `;
 
 exports[`workdone report multi-user report includes Author column and both users' commits 1`] = `
-"Week starting 2026-03-30 (Monday, local time)
+"Week starting 2026-04-06 (Monday, local time)
 
-2026-03-30 (Mon)
+2026-04-08 (Wed)
+Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
+Time   Source      Hash     Author           Files+  -  Δ  Bin  Subject
+-----  ----------  -------  ---------------  -----  -  -  -  ---  -------
+09:00  repo-multi  81db138  bob@example.com      1  2  0  2    0  add migration runner
+
+-------------------------------------------------------------------------------
+
+2026-04-07 (Tue)
+Day total: 1 commits, 1 files, +2 -0, 2, 0 binaries
+Time   Source      Hash     Author             Files+  -  Δ  Bin  Subject
+-----  ----------  -------  -----------------  -----  -  -  -  ---  -------
+14:00  repo-multi  60db86c  alice@example.com      1  2  0  2    0  add result caching
+
+-------------------------------------------------------------------------------
+
+2026-04-06 (Mon)
 Day total: 2 commits, 2 files, +4 -0, 4, 0 binaries
 Time   Source      Hash     Author             Files+  -  Δ  Bin  Subject
 -----  ----------  -------  -----------------  -----  -  -  -  ---  -------
-16:00  repo-multi  5e6eed5  bob@example.com        1  2  0  2    0  add database query builder
-10:00  repo-multi  f0c0a98  alice@example.com      1  2  0  2    0  add data fetching layer
+16:00  repo-multi  f778011  bob@example.com        1  2  0  2    0  add database query builder
+10:00  repo-multi  3dac69d  alice@example.com      1  2  0  2    0  add data fetching layer
 "
 `;

--- a/tests/e2e/report.test.ts
+++ b/tests/e2e/report.test.ts
@@ -192,6 +192,16 @@ describe("workdone report date-range options", () => {
     expect(result.stdout).not.toContain("todays work");
   });
 
+  it("--last-week shows last week's commit and not this week's", async () => {
+    const cfg = await createConfig(dateRangeSource(), [ALICE]);
+    cleanup = cfg.cleanup;
+
+    const result = runCli(["report", "--last-week"], configEnv(cfg.configPath));
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("last week work");
+    expect(result.stdout).not.toContain("todays work");
+  });
+
   it("--since exit code is 0 for a valid date", async () => {
     const cfg = await createConfig(dateRangeSource(), [ALICE]);
     cleanup = cfg.cleanup;

--- a/tests/time.test.ts
+++ b/tests/time.test.ts
@@ -276,4 +276,33 @@ describe("resolveShortcutRange", () => {
     expect(toDateKey(range.start)).toBe("2025-12-01");
     expect(toDateKey(range.end)).toBe("2025-12-31");
   });
+
+  it("last-week: spans Mon 00:00:00 through Sun 23:59:59 of the previous ISO week", () => {
+    // now = Wednesday 2026-03-18; previous ISO week is 2026-03-09 (Mon) – 2026-03-15 (Sun)
+    const range = resolveShortcutRange("last-week", now);
+    expect(toDateKey(range.start)).toBe("2026-03-09");
+    expect(range.start.getHours()).toBe(0);
+    expect(range.start.getMinutes()).toBe(0);
+    expect(range.start.getSeconds()).toBe(0);
+    expect(toDateKey(range.end)).toBe("2026-03-15");
+    expect(range.end.getHours()).toBe(23);
+    expect(range.end.getMinutes()).toBe(59);
+    expect(range.end.getSeconds()).toBe(59);
+  });
+
+  it("last-week: matches --week=-1 exactly", () => {
+    const shortcutRange = resolveShortcutRange("last-week", now);
+    const weekRange = resolveWeekRange({ kind: "relative", offset: -1 }, now);
+    expect(shortcutRange.start.getTime()).toBe(weekRange.start.getTime());
+    expect(shortcutRange.end.getTime()).toBe(weekRange.end.getTime());
+  });
+
+  it("last-week: handles ISO year boundary (early January, previous week is in prior year)", () => {
+    // 2026-01-01 is a Thursday; ISO week 1 of 2026 starts Mon 2025-12-29
+    // So "last week" relative to 2026-01-05 (Mon of ISO week 2) is ISO week 1: 2025-12-29 – 2026-01-04
+    const earlyJan = new Date("2026-01-05T09:00:00");
+    const range = resolveShortcutRange("last-week", earlyJan);
+    expect(toDateKey(range.start)).toBe("2025-12-29");
+    expect(toDateKey(range.end)).toBe("2026-01-04");
+  });
 });


### PR DESCRIPTION
Closes #39

Adds --last-week as an ergonomic alias for --week=-1 (Mon 00:00 - Sun 23:59:59 local time of the previous ISO week).

## Changes
- time.ts: extend Shortcut type; add last-week case in resolveShortcutRange
- cli.ts: parse --last-week flag; mutual-exclusion guards; update help + examples
- tests/time.test.ts: unit tests incl. ISO year-boundary case
- tests/e2e/report.test.ts: e2e test mirroring --week=-1
- snapshots: refresh stale time-dependent snapshots

## Test results
140 pass, 0 fail across 17 files