### PR TITLE
feat: workdone update command — self-update to latest release

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import type { DateRange, Shortcut } from "./core/time";
 import { createNodeSelectionIo, runSelectionSession } from "./core/selection";
 import { addUser, listUsers, removeUser } from "./core/users";
 import { VERSION } from "./core/version";
-import { fetchLatestVersion, getAssetName, isNewerVersion, buildDownloadUrls, downloadAndVerify, replaceBinary } from "./core/updater";
+import { fetchLatestVersion, getAssetName, isNewerVersion, buildDownloadUrls, downloadAndVerify, replaceBinary, cleanupStaleBinary } from "./core/updater";
 import type { FileOps } from "./core/updater";
 import {
   buildSourceSelectionSession,
@@ -1110,6 +1110,8 @@ async function handleUpdate(args: string[]): Promise<void> {
 }
 
 async function main(): Promise<void> {
+  await cleanupStaleBinary(process.execPath, nodeFileOps);
+
   const args = process.argv.slice(2);
   const command = args[0];
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import type { DateRange, Shortcut } from "./core/time";
 import { createNodeSelectionIo, runSelectionSession } from "./core/selection";
 import { addUser, listUsers, removeUser } from "./core/users";
 import { VERSION } from "./core/version";
+import { fetchLatestVersion, getAssetName, isNewerVersion } from "./core/updater";
 import {
   buildSourceSelectionSession,
   formatSelectionEntryLabel,
@@ -39,6 +40,7 @@ COMMANDS
   users list             List configured author emails (falls back to global git email if empty)
   users add <email>      Add an author email to include in reports
   users remove <email>   Remove a configured author email
+  update                 Update workdone to the latest version
   help [command]         Show help for a command
 
 GLOBAL OPTIONS
@@ -351,6 +353,29 @@ EXAMPLES
   workdone sources validate`);
 }
 
+function printUpdateHelp(): void {
+  console.log(`Update workdone to the latest release.
+
+USAGE
+  workdone update
+
+DESCRIPTION
+  Checks the latest release on GitHub and compares it to the installed version.
+
+  If already up to date, prints a confirmation message and exits.
+
+  If a newer version is available, prints the new version number and prompts
+  [y/n] before downloading and replacing the installed binary.
+
+  The downloaded binary is verified with a SHA-256 checksum before the
+  existing binary is replaced. On Windows the old binary is renamed to
+  workdone.old.exe before being replaced, to work around the OS restriction
+  on overwriting a running executable.
+
+EXAMPLES
+  workdone update`);
+}
+
 function suggestCommand(unknown: string): string | null {
   if (unknown === "sourced") {
     return "sources";
@@ -360,6 +385,9 @@ function suggestCommand(unknown: string): string | null {
   }
   if (unknown === "user") {
     return "users";
+  }
+  if (unknown === "upate" || unknown === "updaet" || unknown === "upadte") {
+    return "update";
   }
   return null;
 }
@@ -1012,9 +1040,39 @@ function printHelpForPath(pathParts: string[]): void {
     case "users":
       printUsersHelp();
       return;
+    case "update":
+      printUpdateHelp();
+      return;
     default:
       fail(`unknown help topic '${joined}'\nTry: workdone --help`);
   }
+}
+
+async function handleUpdate(args: string[]): Promise<void> {
+  if (args[0] === "-h" || args[0] === "--help") {
+    printUpdateHelp();
+    return;
+  }
+
+  try {
+    getAssetName();
+  } catch {
+    fail(`workdone update is not supported on this platform (${process.platform}/${process.arch})`);
+  }
+
+  let latestVersion: string;
+  try {
+    latestVersion = await fetchLatestVersion(fetch);
+  } catch (err) {
+    fail(`failed to check for updates: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (!isNewerVersion(VERSION, latestVersion)) {
+    console.log(`Already on the latest version (${VERSION}).`);
+    return;
+  }
+
+  console.log(`New version ${latestVersion} available (current: ${VERSION}).`);
 }
 
 async function main(): Promise<void> {
@@ -1062,6 +1120,11 @@ async function main(): Promise<void> {
 
   if (command === "users") {
     await handleUsers(args.slice(1));
+    return;
+  }
+
+  if (command === "update") {
+    await handleUpdate(args.slice(1));
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 
 import path from "node:path";
-import { stat } from "node:fs/promises";
+import { stat, rename, writeFile, unlink, chmod } from "node:fs/promises";
+import { createInterface } from "node:readline/promises";
 import { loadConfig, saveConfig } from "./core/config";
 import { getGlobalGitUserEmail, syncGitSource } from "./core/git";
 import { printReport, printValidationResults } from "./core/output";
@@ -12,7 +13,8 @@ import type { DateRange, Shortcut } from "./core/time";
 import { createNodeSelectionIo, runSelectionSession } from "./core/selection";
 import { addUser, listUsers, removeUser } from "./core/users";
 import { VERSION } from "./core/version";
-import { fetchLatestVersion, getAssetName, isNewerVersion } from "./core/updater";
+import { fetchLatestVersion, getAssetName, isNewerVersion, buildDownloadUrls, downloadAndVerify, replaceBinary } from "./core/updater";
+import type { FileOps } from "./core/updater";
 import {
   buildSourceSelectionSession,
   formatSelectionEntryLabel,
@@ -1048,14 +1050,17 @@ function printHelpForPath(pathParts: string[]): void {
   }
 }
 
+const nodeFileOps: FileOps = { rename, writeFile, unlink, chmod };
+
 async function handleUpdate(args: string[]): Promise<void> {
   if (args[0] === "-h" || args[0] === "--help") {
     printUpdateHelp();
     return;
   }
 
+  let assetName: string;
   try {
-    getAssetName();
+    assetName = getAssetName();
   } catch {
     fail(`workdone update is not supported on this platform (${process.platform}/${process.arch})`);
   }
@@ -1073,6 +1078,35 @@ async function handleUpdate(args: string[]): Promise<void> {
   }
 
   console.log(`New version ${latestVersion} available (current: ${VERSION}).`);
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await rl.question("Update? [y/n] ");
+  rl.close();
+
+  if (answer.trim().toLowerCase() !== "y") {
+    console.log("Update cancelled.");
+    return;
+  }
+
+  const { binaryUrl, checksumUrl } = buildDownloadUrls(latestVersion, assetName);
+  process.stdout.write(`Downloading workdone ${latestVersion}...`);
+
+  let binaryData: Uint8Array;
+  try {
+    binaryData = await downloadAndVerify(fetch, binaryUrl, checksumUrl);
+  } catch (err) {
+    process.stdout.write("\n");
+    fail(`update failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  process.stdout.write(" done\n");
+
+  try {
+    await replaceBinary(process.execPath, binaryData, process.platform, nodeFileOps);
+  } catch (err) {
+    fail(`failed to replace binary: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  console.log(`Updated to ${latestVersion}.`);
 }
 
 async function main(): Promise<void> {

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -3,6 +3,13 @@ const API_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
 
 export type Fetcher = (url: string, init?: RequestInit) => Promise<Response>;
 
+export interface FileOps {
+  writeFile: (path: string, data: Uint8Array) => Promise<void>;
+  rename: (oldPath: string, newPath: string) => Promise<void>;
+  unlink: (path: string) => Promise<void>;
+  chmod: (path: string, mode: number) => Promise<void>;
+}
+
 function stripV(version: string): string {
   return version.startsWith("v") ? version.slice(1) : version;
 }
@@ -55,4 +62,89 @@ export function detectAssetName(platform: string, arch: string): string {
 
 export function getAssetName(): string {
   return detectAssetName(process.platform, process.arch);
+}
+
+export function buildDownloadUrls(
+  version: string,
+  assetName: string,
+): { binaryUrl: string; checksumUrl: string } {
+  const tag = version.startsWith("v") ? version : `v${version}`;
+  const base = `https://github.com/${REPO}/releases/download/${tag}`;
+  return {
+    binaryUrl: `${base}/${assetName}`,
+    checksumUrl: `${base}/${assetName}.sha256`,
+  };
+}
+
+async function sha256Hex(data: Uint8Array): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function downloadAndVerify(
+  fetcher: Fetcher,
+  binaryUrl: string,
+  checksumUrl: string,
+): Promise<Uint8Array> {
+  let binaryRes: Response;
+  try {
+    binaryRes = await fetcher(binaryUrl);
+  } catch (err) {
+    throw new Error(
+      `failed to download binary: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!binaryRes.ok) {
+    throw new Error(`failed to download binary: HTTP ${binaryRes.status}`);
+  }
+  const binaryData = new Uint8Array(await binaryRes.arrayBuffer());
+
+  let checksumRes: Response;
+  try {
+    checksumRes = await fetcher(checksumUrl);
+  } catch (err) {
+    throw new Error(
+      `failed to download checksum: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!checksumRes.ok) {
+    throw new Error(`failed to download checksum: HTTP ${checksumRes.status}`);
+  }
+  const checksumText = await checksumRes.text();
+  const expectedHash = checksumText.trim().split(/\s+/)[0];
+  if (!expectedHash) {
+    throw new Error("checksum file was empty");
+  }
+
+  const actualHash = await sha256Hex(binaryData);
+  if (actualHash !== expectedHash.toLowerCase()) {
+    throw new Error("checksum verification failed: downloaded binary may be corrupted");
+  }
+
+  return binaryData;
+}
+
+export async function replaceBinary(
+  currentPath: string,
+  binaryData: Uint8Array,
+  platform: string,
+  fileOps: FileOps,
+): Promise<void> {
+  if (platform === "win32") {
+    const oldPath = currentPath.endsWith(".exe")
+      ? currentPath.slice(0, -4) + ".old.exe"
+      : currentPath + ".old";
+    await fileOps.rename(currentPath, oldPath);
+    await fileOps.writeFile(currentPath, binaryData);
+    try {
+      await fileOps.unlink(oldPath);
+    } catch {
+      // Non-fatal: will be cleaned up by cleanupStaleBinary on next run
+    }
+  } else {
+    await fileOps.writeFile(currentPath, binaryData);
+    await fileOps.chmod(currentPath, 0o755);
+  }
 }

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -1,0 +1,58 @@
+const REPO = "codeunity/workdone";
+const API_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
+
+export type Fetcher = (url: string, init?: RequestInit) => Promise<Response>;
+
+function stripV(version: string): string {
+  return version.startsWith("v") ? version.slice(1) : version;
+}
+
+export async function fetchLatestVersion(fetcher: Fetcher): Promise<string> {
+  let res: Response;
+  try {
+    res = await fetcher(API_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+  } catch (err) {
+    throw new Error(
+      `network error while checking for updates: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!res.ok) {
+    throw new Error(`GitHub API returned ${res.status} ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as { tag_name?: unknown };
+  if (typeof data.tag_name !== "string" || !data.tag_name) {
+    throw new Error("GitHub API response missing tag_name");
+  }
+
+  return stripV(data.tag_name);
+}
+
+export function isNewerVersion(current: string, latest: string): boolean {
+  const parse = (v: string): number[] => stripV(v).split(".").map(Number);
+  const c = parse(current);
+  const l = parse(latest);
+  for (let i = 0; i < 3; i++) {
+    const lv = l[i] ?? 0;
+    const cv = c[i] ?? 0;
+    if (lv > cv) return true;
+    if (lv < cv) return false;
+  }
+  return false;
+}
+
+export function detectAssetName(platform: string, arch: string): string {
+  if (platform === "win32" && arch === "x64") return "workdone-windows-x64.exe";
+  if (platform === "darwin" && arch === "arm64") return "workdone-darwin-arm64";
+  throw new Error(`unsupported platform: ${platform}/${arch}`);
+}
+
+export function getAssetName(): string {
+  return detectAssetName(process.platform, process.arch);
+}

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -126,8 +126,7 @@ export async function downloadAndVerify(
   return binaryData;
 }
 
-export async function replaceBinary(
-  currentPath: string,
+export async function replaceBinary(  currentPath: string,
   binaryData: Uint8Array,
   platform: string,
   fileOps: FileOps,
@@ -146,5 +145,18 @@ export async function replaceBinary(
   } else {
     await fileOps.writeFile(currentPath, binaryData);
     await fileOps.chmod(currentPath, 0o755);
+  }
+}
+
+export async function cleanupStaleBinary(
+  currentPath: string,
+  fileOps: Pick<FileOps, "unlink">,
+): Promise<void> {
+  if (!currentPath.endsWith(".exe")) return;
+  const stalePath = currentPath.slice(0, -4) + ".old.exe";
+  try {
+    await fileOps.unlink(stalePath);
+  } catch {
+    // Silently ignore — file may not exist or may still be locked
   }
 }

--- a/tests/updater.test.ts
+++ b/tests/updater.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "bun:test";
-import { detectAssetName, fetchLatestVersion, isNewerVersion } from "../src/core/updater";
-import type { Fetcher } from "../src/core/updater";
+import {
+  buildDownloadUrls,
+  detectAssetName,
+  downloadAndVerify,
+  fetchLatestVersion,
+  isNewerVersion,
+  replaceBinary,
+} from "../src/core/updater";
+import type { Fetcher, FileOps } from "../src/core/updater";
 
 // ---------------------------------------------------------------------------
 // fetchLatestVersion
@@ -122,5 +129,240 @@ describe("detectAssetName", () => {
 
   it("throws for an unsupported arch on a known OS", () => {
     expect(() => detectAssetName("win32", "arm64")).toThrow("unsupported platform");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDownloadUrls
+// ---------------------------------------------------------------------------
+
+describe("buildDownloadUrls", () => {
+  it("builds correct URLs from a bare version string", () => {
+    const { binaryUrl, checksumUrl } = buildDownloadUrls("1.2.3", "workdone-windows-x64.exe");
+    expect(binaryUrl).toBe(
+      "https://github.com/codeunity/workdone/releases/download/v1.2.3/workdone-windows-x64.exe",
+    );
+    expect(checksumUrl).toBe(
+      "https://github.com/codeunity/workdone/releases/download/v1.2.3/workdone-windows-x64.exe.sha256",
+    );
+  });
+
+  it("does not double-prefix v when version already starts with v", () => {
+    const { binaryUrl } = buildDownloadUrls("v1.2.3", "workdone-darwin-arm64");
+    expect(binaryUrl).toContain("/download/v1.2.3/");
+    expect(binaryUrl).not.toContain("/download/vv");
+  });
+
+  it("builds correct macOS arm64 URLs", () => {
+    const { binaryUrl, checksumUrl } = buildDownloadUrls("0.9.0", "workdone-darwin-arm64");
+    expect(binaryUrl).toBe(
+      "https://github.com/codeunity/workdone/releases/download/v0.9.0/workdone-darwin-arm64",
+    );
+    expect(checksumUrl).toBe(
+      "https://github.com/codeunity/workdone/releases/download/v0.9.0/workdone-darwin-arm64.sha256",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadAndVerify
+// ---------------------------------------------------------------------------
+
+async function computeSha256Hex(data: Uint8Array): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function makeBinaryFetcher(binaryData: Uint8Array, correctHash: string): Fetcher {
+  return async (url: string) => {
+    if (url.endsWith(".sha256")) {
+      return new Response(`${correctHash}  workdone-windows-x64.exe\n`);
+    }
+    return new Response(binaryData.buffer as ArrayBuffer);
+  };
+}
+
+describe("downloadAndVerify", () => {
+  it("resolves with binary data when checksum matches", async () => {
+    const binaryData = new TextEncoder().encode("fake binary payload");
+    const correctHash = await computeSha256Hex(binaryData);
+    const fetcher = makeBinaryFetcher(binaryData, correctHash);
+
+    const result = await downloadAndVerify(
+      fetcher,
+      "https://example.com/workdone-windows-x64.exe",
+      "https://example.com/workdone-windows-x64.exe.sha256",
+    );
+    expect(result).toEqual(binaryData);
+  });
+
+  it("throws when the checksum does not match", async () => {
+    const binaryData = new TextEncoder().encode("some binary");
+    const fetcher = makeBinaryFetcher(binaryData, "deadbeef".repeat(8));
+
+    await expect(
+      downloadAndVerify(
+        fetcher,
+        "https://example.com/workdone-windows-x64.exe",
+        "https://example.com/workdone-windows-x64.exe.sha256",
+      ),
+    ).rejects.toThrow("checksum verification failed");
+  });
+
+  it("throws when binary download returns a non-200 status", async () => {
+    const fetcher: Fetcher = async () => new Response("Not Found", { status: 404 });
+
+    await expect(
+      downloadAndVerify(
+        fetcher,
+        "https://example.com/workdone-windows-x64.exe",
+        "https://example.com/workdone-windows-x64.exe.sha256",
+      ),
+    ).rejects.toThrow("HTTP 404");
+  });
+
+  it("throws when binary download fails with a network error", async () => {
+    const fetcher: Fetcher = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+
+    await expect(
+      downloadAndVerify(
+        fetcher,
+        "https://example.com/workdone-windows-x64.exe",
+        "https://example.com/workdone-windows-x64.exe.sha256",
+      ),
+    ).rejects.toThrow("failed to download binary");
+  });
+
+  it("throws when checksum download returns a non-200 status", async () => {
+    const binaryData = new TextEncoder().encode("binary content");
+    let calls = 0;
+    const fetcher: Fetcher = async () => {
+      calls += 1;
+      if (calls === 1) return new Response(binaryData.buffer as ArrayBuffer);
+      return new Response("Not Found", { status: 404 });
+    };
+
+    await expect(
+      downloadAndVerify(
+        fetcher,
+        "https://example.com/workdone-windows-x64.exe",
+        "https://example.com/workdone-windows-x64.exe.sha256",
+      ),
+    ).rejects.toThrow("failed to download checksum");
+  });
+
+  it("throws when the checksum file is empty", async () => {
+    const binaryData = new TextEncoder().encode("binary content");
+    const fetcher: Fetcher = async (url) => {
+      if (url.endsWith(".sha256")) return new Response("   ");
+      return new Response(binaryData.buffer as ArrayBuffer);
+    };
+
+    await expect(
+      downloadAndVerify(
+        fetcher,
+        "https://example.com/workdone-windows-x64.exe",
+        "https://example.com/workdone-windows-x64.exe.sha256",
+      ),
+    ).rejects.toThrow("checksum file was empty");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replaceBinary
+// ---------------------------------------------------------------------------
+
+function makeFileOps(opts?: { unlinkShouldFail?: boolean }): {
+  ops: FileOps;
+  written: Map<string, Uint8Array>;
+  renamed: Array<[string, string]>;
+  deleted: string[];
+  chmods: Array<[string, number]>;
+} {
+  const written = new Map<string, Uint8Array>();
+  const renamed: Array<[string, string]> = [];
+  const deleted: string[] = [];
+  const chmods: Array<[string, number]> = [];
+
+  const ops: FileOps = {
+    writeFile: async (p, data) => {
+      written.set(p, data);
+    },
+    rename: async (src, dst) => {
+      renamed.push([src, dst]);
+    },
+    unlink: async (p) => {
+      if (opts?.unlinkShouldFail) throw new Error("file is locked");
+      deleted.push(p);
+    },
+    chmod: async (p, mode) => {
+      chmods.push([p, mode]);
+    },
+  };
+
+  return { ops, written, renamed, deleted, chmods };
+}
+
+describe("replaceBinary — Windows", () => {
+  const binaryData = new TextEncoder().encode("new binary content");
+  const currentPath = "C:\\Users\\user\\.workdone\\bin\\workdone.exe";
+  const expectedOldPath = "C:\\Users\\user\\.workdone\\bin\\workdone.old.exe";
+
+  it("renames the old binary and writes the new one", async () => {
+    const { ops, written, renamed } = makeFileOps();
+    await replaceBinary(currentPath, binaryData, "win32", ops);
+
+    expect(renamed).toEqual([[currentPath, expectedOldPath]]);
+    expect(written.get(currentPath)).toEqual(binaryData);
+  });
+
+  it("deletes the renamed old binary after a successful write", async () => {
+    const { ops, deleted } = makeFileOps();
+    await replaceBinary(currentPath, binaryData, "win32", ops);
+
+    expect(deleted).toContain(expectedOldPath);
+  });
+
+  it("does not throw when unlink of the old binary fails", async () => {
+    const { ops } = makeFileOps({ unlinkShouldFail: true });
+    await expect(replaceBinary(currentPath, binaryData, "win32", ops)).resolves.toBeUndefined();
+  });
+
+  it("still writes the new binary even when unlink fails", async () => {
+    const { ops, written } = makeFileOps({ unlinkShouldFail: true });
+    await replaceBinary(currentPath, binaryData, "win32", ops);
+
+    expect(written.get(currentPath)).toEqual(binaryData);
+  });
+});
+
+describe("replaceBinary — macOS", () => {
+  const binaryData = new TextEncoder().encode("new binary content");
+  const currentPath = "/home/user/.workdone/bin/workdone";
+
+  it("writes the new binary directly to the current path", async () => {
+    const { ops, written } = makeFileOps();
+    await replaceBinary(currentPath, binaryData, "darwin", ops);
+
+    expect(written.get(currentPath)).toEqual(binaryData);
+  });
+
+  it("sets executable permissions (0o755) on the new binary", async () => {
+    const { ops, chmods } = makeFileOps();
+    await replaceBinary(currentPath, binaryData, "darwin", ops);
+
+    expect(chmods).toEqual([[currentPath, 0o755]]);
+  });
+
+  it("does not rename or delete any file", async () => {
+    const { ops, renamed, deleted } = makeFileOps();
+    await replaceBinary(currentPath, binaryData, "darwin", ops);
+
+    expect(renamed).toHaveLength(0);
+    expect(deleted).toHaveLength(0);
   });
 });

--- a/tests/updater.test.ts
+++ b/tests/updater.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "bun:test";
+import { detectAssetName, fetchLatestVersion, isNewerVersion } from "../src/core/updater";
+import type { Fetcher } from "../src/core/updater";
+
+// ---------------------------------------------------------------------------
+// fetchLatestVersion
+// ---------------------------------------------------------------------------
+
+function makeFetcher(status: number, body: unknown): Fetcher {
+  return async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+}
+
+function makeFailingFetcher(message: string): Fetcher {
+  return async () => {
+    throw new Error(message);
+  };
+}
+
+describe("fetchLatestVersion", () => {
+  it("returns the version string from a successful response", async () => {
+    const fetcher = makeFetcher(200, { tag_name: "v1.2.3" });
+    expect(await fetchLatestVersion(fetcher)).toBe("1.2.3");
+  });
+
+  it("strips a leading v from the tag_name", async () => {
+    const fetcher = makeFetcher(200, { tag_name: "v0.9.0" });
+    expect(await fetchLatestVersion(fetcher)).toBe("0.9.0");
+  });
+
+  it("returns a version without a v prefix unchanged", async () => {
+    const fetcher = makeFetcher(200, { tag_name: "2.0.0" });
+    expect(await fetchLatestVersion(fetcher)).toBe("2.0.0");
+  });
+
+  it("throws when the API returns a non-200 status", async () => {
+    const fetcher = makeFetcher(404, { message: "Not Found" });
+    await expect(fetchLatestVersion(fetcher)).rejects.toThrow("404");
+  });
+
+  it("throws when the response body has no tag_name", async () => {
+    const fetcher = makeFetcher(200, { name: "Latest" });
+    await expect(fetchLatestVersion(fetcher)).rejects.toThrow("tag_name");
+  });
+
+  it("throws when tag_name is an empty string", async () => {
+    const fetcher = makeFetcher(200, { tag_name: "" });
+    await expect(fetchLatestVersion(fetcher)).rejects.toThrow("tag_name");
+  });
+
+  it("wraps a network error with a descriptive message", async () => {
+    const fetcher = makeFailingFetcher("ECONNREFUSED");
+    await expect(fetchLatestVersion(fetcher)).rejects.toThrow("network error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isNewerVersion
+// ---------------------------------------------------------------------------
+
+describe("isNewerVersion", () => {
+  it("returns false when versions are equal", () => {
+    expect(isNewerVersion("1.0.0", "1.0.0")).toBe(false);
+  });
+
+  it("returns true when latest has a higher patch", () => {
+    expect(isNewerVersion("1.0.0", "1.0.1")).toBe(true);
+  });
+
+  it("returns true when latest has a higher minor", () => {
+    expect(isNewerVersion("1.0.0", "1.1.0")).toBe(true);
+  });
+
+  it("returns true when latest has a higher major", () => {
+    expect(isNewerVersion("1.0.0", "2.0.0")).toBe(true);
+  });
+
+  it("returns false when installed is ahead of latest", () => {
+    expect(isNewerVersion("2.0.0", "1.9.9")).toBe(false);
+  });
+
+  it("handles v-prefixes on both sides", () => {
+    expect(isNewerVersion("v1.0.0", "v1.0.1")).toBe(true);
+  });
+
+  it("handles a v-prefix on current only", () => {
+    expect(isNewerVersion("v0.9.0", "0.10.0")).toBe(true);
+  });
+
+  it("handles a v-prefix on latest only", () => {
+    expect(isNewerVersion("0.9.0", "v0.10.0")).toBe(true);
+  });
+
+  it("correctly compares multi-digit minor versions (10 > 9)", () => {
+    expect(isNewerVersion("0.9.0", "0.10.0")).toBe(true);
+  });
+
+  it("returns false for 0.10.0 vs 0.9.0 (installed is ahead)", () => {
+    expect(isNewerVersion("0.10.0", "0.9.0")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectAssetName
+// ---------------------------------------------------------------------------
+
+describe("detectAssetName", () => {
+  it("returns the Windows x64 asset name", () => {
+    expect(detectAssetName("win32", "x64")).toBe("workdone-windows-x64.exe");
+  });
+
+  it("returns the macOS arm64 asset name", () => {
+    expect(detectAssetName("darwin", "arm64")).toBe("workdone-darwin-arm64");
+  });
+
+  it("throws for an unsupported platform", () => {
+    expect(() => detectAssetName("linux", "x64")).toThrow("unsupported platform");
+  });
+
+  it("throws for an unsupported arch on a known OS", () => {
+    expect(() => detectAssetName("win32", "arm64")).toThrow("unsupported platform");
+  });
+});

--- a/tests/updater.test.ts
+++ b/tests/updater.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   buildDownloadUrls,
+  cleanupStaleBinary,
   detectAssetName,
   downloadAndVerify,
   fetchLatestVersion,
@@ -363,6 +364,46 @@ describe("replaceBinary — macOS", () => {
     await replaceBinary(currentPath, binaryData, "darwin", ops);
 
     expect(renamed).toHaveLength(0);
+    expect(deleted).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanupStaleBinary
+// ---------------------------------------------------------------------------
+
+describe("cleanupStaleBinary", () => {
+  it("deletes the .old.exe file when it exists", async () => {
+    const deleted: string[] = [];
+    const ops = { unlink: async (p: string) => { deleted.push(p); } };
+
+    await cleanupStaleBinary("C:\\workdone\\bin\\workdone.exe", ops);
+
+    expect(deleted).toEqual(["C:\\workdone\\bin\\workdone.old.exe"]);
+  });
+
+  it("does not throw when the stale file does not exist", async () => {
+    const ops = { unlink: async () => { throw new Error("ENOENT: no such file"); } };
+
+    await expect(
+      cleanupStaleBinary("C:\\workdone\\bin\\workdone.exe", ops),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw when unlink fails for any other reason", async () => {
+    const ops = { unlink: async () => { throw new Error("EPERM: permission denied"); } };
+
+    await expect(
+      cleanupStaleBinary("C:\\workdone\\bin\\workdone.exe", ops),
+    ).resolves.toBeUndefined();
+  });
+
+  it("is a no-op on non-Windows paths (no .exe suffix)", async () => {
+    const deleted: string[] = [];
+    const ops = { unlink: async (p: string) => { deleted.push(p); } };
+
+    await cleanupStaleBinary("/home/user/.workdone/bin/workdone", ops);
+
     expect(deleted).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Implements the `workdone update` command as specified in issue #42, across three clean commits.

## What's new

Run `workdone update` to check for a newer release and, if one is available, apply it in place with checksum verification.

```
$ workdone update
New version 0.10.0 available (current: 0.9.0).
Update? [y/n] y
Downloading workdone 0.10.0... done
Updated to 0.10.0.
```

Or when already up to date:

```
$ workdone update
Already on the latest version (0.9.0).
```

## Changes

### `src/core/updater.ts` (new)
A deep, fully-testable module with all side effects injected:
- `fetchLatestVersion(fetcher)` — queries the GitHub Releases API for the latest tag
- `isNewerVersion(current, latest)` — semver comparison with `v`-prefix tolerance
- `detectAssetName(platform, arch)` / `getAssetName()` — maps runtime platform to the correct release asset name (`workdone-windows-x64.exe`, `workdone-darwin-arm64`)
- `buildDownloadUrls(version, assetName)` — constructs binary + checksum download URLs
- `downloadAndVerify(fetcher, binaryUrl, checksumUrl)` — downloads binary and `.sha256`, verifies SHA-256 via `crypto.subtle`, returns the verified `Uint8Array`
- `replaceBinary(currentPath, data, platform, fileOps)` — rename-then-replace on Windows (`.old.exe`), direct overwrite + `chmod 0o755` on macOS; `unlink` failure on Windows is non-fatal
- `cleanupStaleBinary(currentPath, fileOps)` — silently removes any `.old.exe` left from a previous update; no-op on non-Windows paths; all errors swallowed

### `src/cli.ts`
- `workdone update` command wired end-to-end: platform check → version fetch → prompt `[y/n]` → download → verify → replace → success message
- `printUpdateHelp()` for `workdone update --help` and `workdone help update`
- `update` listed in top-level `workdone --help` COMMANDS section
- Typo suggestions in `suggestCommand` (`updaet`, `upate`, `upadte`)
- `cleanupStaleBinary` called as first line of `main()` on every invocation

### `tests/updater.test.ts` (new)
41 unit tests, all offline — no network or disk access required:
- `fetchLatestVersion`: 7 cases (success, non-200, missing field, empty field, network error)
- `isNewerVersion`: 10 cases (equal, ahead, behind, multi-digit, `v`-prefix variants)
- `detectAssetName`: 4 cases
- `buildDownloadUrls`: 3 cases
- `downloadAndVerify`: 6 cases (match, mismatch, binary HTTP error, network error, checksum HTTP error, empty checksum)
- `replaceBinary — Windows`: 4 cases (rename+write, delete, unlink failure non-fatal, write still happens)
- `replaceBinary — macOS`: 3 cases (write, chmod, no rename/delete)
- `cleanupStaleBinary`: 4 cases (file present, ENOENT, other error, non-Windows no-op)

## Test results

```
181 pass, 0 fail
Ran 181 tests across 18 files.
```

Closes #42
