### PR TITLE
fix: use atomic rename for macOS self-update to prevent SIGKILL

### DIFF
--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -143,8 +143,15 @@ export async function replaceBinary(  currentPath: string,
       // Non-fatal: will be cleaned up by cleanupStaleBinary on next run
     }
   } else {
-    await fileOps.writeFile(currentPath, binaryData);
-    await fileOps.chmod(currentPath, 0o755);
+    // Write to a temp file first, then atomically rename over the target.
+    // Writing directly to process.execPath while the binary is running causes
+    // SIGKILL on macOS because the kernel detects modification of an active
+    // code-signed executable. An atomic rename swaps the directory entry to a
+    // new inode, leaving the running process's mapping of the old inode intact.
+    const tempPath = currentPath + ".new";
+    await fileOps.writeFile(tempPath, binaryData);
+    await fileOps.chmod(tempPath, 0o755);
+    await fileOps.rename(tempPath, currentPath);
   }
 }
 

--- a/tests/updater.test.ts
+++ b/tests/updater.test.ts
@@ -344,27 +344,28 @@ describe("replaceBinary — Windows", () => {
 describe("replaceBinary — macOS", () => {
   const binaryData = new TextEncoder().encode("new binary content");
   const currentPath = "/home/user/.workdone/bin/workdone";
+  const expectedTempPath = currentPath + ".new";
 
-  it("writes the new binary directly to the current path", async () => {
+  it("writes the new binary to a .new temp file, not directly to the current path", async () => {
     const { ops, written } = makeFileOps();
     await replaceBinary(currentPath, binaryData, "darwin", ops);
 
-    expect(written.get(currentPath)).toEqual(binaryData);
+    expect(written.get(expectedTempPath)).toEqual(binaryData);
+    expect(written.has(currentPath)).toBe(false);
   });
 
-  it("sets executable permissions (0o755) on the new binary", async () => {
+  it("sets executable permissions (0o755) on the temp file before renaming", async () => {
     const { ops, chmods } = makeFileOps();
     await replaceBinary(currentPath, binaryData, "darwin", ops);
 
-    expect(chmods).toEqual([[currentPath, 0o755]]);
+    expect(chmods).toEqual([[expectedTempPath, 0o755]]);
   });
 
-  it("does not rename or delete any file", async () => {
-    const { ops, renamed, deleted } = makeFileOps();
+  it("atomically renames the temp file over the current path", async () => {
+    const { ops, renamed } = makeFileOps();
     await replaceBinary(currentPath, binaryData, "darwin", ops);
 
-    expect(renamed).toHaveLength(0);
-    expect(deleted).toHaveLength(0);
+    expect(renamed).toEqual([[expectedTempPath, currentPath]]);
   });
 });
 


### PR DESCRIPTION
## Problem

Fixes #47

`workdone update` on macOS (Apple Silicon) results in `zsh: killed`. A subsequent reinstall via `install.sh` then fails with `error: installed binary did not return a version` because the binary was left corrupted/partially-written.

**Root cause:** `replaceBinary` on macOS called `writeFile(process.execPath, binaryData)` — writing directly over the currently-executing binary. On macOS, the kernel enforces code-signing integrity on active Mach-O executables and sends SIGKILL to any process that modifies its own code pages in place.

## Fix

Change the non-Windows path in `replaceBinary` to use the same write-to-temp + atomic rename pattern already used on Windows:

1. Write new binary to `currentPath + ".new"`
2. `chmod 0o755` the temp file
3. `rename(tempPath, currentPath)` — atomic POSIX rename

The `rename(2)` syscall only changes the directory entry; the old inode (with its currently-executing code pages) is never touched. The running process exits cleanly, and the updated binary is picked up on next invocation.

## Changes

- `src/core/updater.ts` — `replaceBinary` non-Windows path: write→chmod→rename instead of direct write→chmod
- `tests/updater.test.ts` — updated three `replaceBinary — macOS` tests to assert the new temp-file + rename behaviour